### PR TITLE
10 user privacy

### DIFF
--- a/mentorship/users/permissions.py
+++ b/mentorship/users/permissions.py
@@ -1,0 +1,6 @@
+from rest_framework import permissions
+
+class UserDetailPermission(permissions.BasePermission):
+    
+    def has_object_permission(self, request, view, obj):
+        return bool(obj == request.user or request.user.is_staff)

--- a/mentorship/users/serializers.py
+++ b/mentorship/users/serializers.py
@@ -24,7 +24,6 @@ class CustomUserSerializer(serializers.ModelSerializer):
         instance.mobile = validated_data.get('mobile',instance.mobile)
         instance.location = validated_data.get('location',instance.location)
         instance.cv = validated_data.get('cv',instance.cv)
-        instance.skills = validated_data.get('skills',instance.skills)
         instance.social_account = validated_data.get('social_account',instance.social_account)
         instance.linkedin_account = validated_data.get('linkedin_account',instance.linkedin_account)
         instance.save()

--- a/mentorship/users/views.py
+++ b/mentorship/users/views.py
@@ -6,11 +6,21 @@ from .models import CustomUser
 from .serializers import CustomUserSerializer
 
 class UserList(APIView):
-    def get(self, request):
-        users = CustomUser.objects.all()
-        serializer = CustomUserSerializer(users, many=True)
-        return Response(serializer.data)
-
+    def get(self,request):
+        if request.user.is_staff:
+            users = CustomUser.objects.all()
+            serializer = CustomUserSerializer(users, many=True)
+            return Response(serializer.data)
+        elif request.user.is_authenticated:
+            users = CustomUser.objects.all().filter(pk=self.request.user.id)
+            serializer = CustomUserSerializer(users, many=True)
+            return Response(serializer.data)
+        else:
+            return Response(
+                { "detail": "You do not have permission to perform this action." }, 
+                status=status.HTTP_401_UNAUTHORIZED
+            )
+        
     def post(self, request):
         serializer = CustomUserSerializer(data=request.data)
         if serializer.is_valid():

--- a/mentorship/users/views.py
+++ b/mentorship/users/views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from .models import CustomUser
 from .serializers import CustomUserSerializer
+from .permissions import UserDetailPermission
 
 class UserList(APIView):
     def get(self,request):
@@ -29,9 +30,13 @@ class UserList(APIView):
         return Response(serializer.errors)
 
 class UserDetail(APIView):
+    permission_classes = [UserDetailPermission]
+
     def get_object(self, pk):
         try:
-            return CustomUser.objects.get(pk=pk)
+            user = CustomUser.objects.get(pk=pk)
+            self.check_object_permissions(self.request,user)
+            return user
         except CustomUser.DoesNotExist:
             raise Http404
         


### PR DESCRIPTION
# We don't want to be like optus!
- Given this day and age, we understand how important it is to protect PII.

## This pull request resolves two issues with regards to keeping users PII data safe:
Issue #10 
- Previously, anyone could hit the `/users/` endpoint and obtain all user data.
- This merge will prevent unauthorised users from making successful get requests to this end point or the `/users/id/` endpoint
- Authenticated users that are not authorised as staff will only be able to return their own user object when making GET requests to `/users/` endpoint and will only be able to successfully return their own user when hitting the `/users/id/` endpoint
- There are no changes for authenticated staff users. They are still able to view all user information for all users.

Issue #12 
- Previously, anyone could update the user object - even unauthenticated users!
- This change prevents:
        -  unauthenticated users from updating user objects
        - non-staff authenticated users from updating other user objects (other than their own user object)

## A note on fields
- At this stage, the skills field has been commented out of the update function in the UserDetail serializer, as this is returning errors due to the many to many model that has been implemented. I believe this to be being investigated under #7.
- Though there is restriction around which users can can modify which user objects, users are still able to view all fields for objects they are able to view and modify. This has been logged under issue #2 .
- The user PUT request has been designed for non staff users. This means only certain fields are available for modifying. This is great for the bulk of users, but we want admins and staff to be allowed to modify additional fields (e.g. onboarding status and private notes). This has been raised in issue #6 