### PR TITLE
9 any user can create themselves as staff or admin

### DIFF
--- a/mentorship/users/models.py
+++ b/mentorship/users/models.py
@@ -7,6 +7,7 @@ class CustomUser(AbstractUser):
   skills = models.ManyToManyField(
         to='users.Skill',  # use a string in the format `app_name.model_name` to reference models to avoid issues using the model before it was defined
         related_name='user_profiles',  # the name for that relation from the point of view of a skill
+        null=True
     )
   onboarding_status = models.CharField(
       max_length=200,

--- a/mentorship/users/models.py
+++ b/mentorship/users/models.py
@@ -1,43 +1,44 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 class CustomUser(AbstractUser):
-  mobile = models.CharField(max_length=10)
-  location = models.CharField(max_length=200)
-  cv = models.URLField(max_length=200)
-  skills = models.ManyToManyField(
+    mobile = models.CharField(max_length=10)
+    location = models.CharField(max_length=200)
+    cv = models.URLField(max_length=200)
+    skills = models.ManyToManyField(
         to='users.Skill',  # use a string in the format `app_name.model_name` to reference models to avoid issues using the model before it was defined
         related_name='user_profiles',  # the name for that relation from the point of view of a skill
         null=True
     )
-  onboarding_status = models.CharField(
-      max_length=200,
-      choices=[
-          ("Applied", "Applied"),
-          ("Validated", "Validated"),
-          ("Interviewed", "Interviewed"),
-          ("Ranked", "Ranked"),
-          ("Accepted", "Accepted"),
-          ("Onboarded", "Onboarded"),
-          ("Ready", "Ready")
-      ],
-      default="Applied"
-  )
-  rank = models.CharField(
-      max_length=200,
-      null=True,
-      choices=[
-          ("Junior", "Junior"),
-          ("Mid-level", "Mid-level"),
-          ("Lead", "Lead")
-      ],
-      default=None
-  )
-  social_account = models.URLField(max_length=200, null=True)
-  linkedin_account = models.URLField(max_length=200,null=True)
-  private_notes = models.TextField(null=True)
-  def __str__(self):
-    return self.username
-  
+    onboarding_status = models.CharField(
+        max_length=200,
+        choices=[
+            ("Applied", "Applied"),
+            ("Validated", "Validated"),
+            ("Interviewed", "Interviewed"),
+            ("Ranked", "Ranked"),
+            ("Accepted", "Accepted"),
+            ("Onboarded", "Onboarded"),
+            ("Ready", "Ready")
+        ],
+        default="Applied"
+    )
+    rank = models.CharField(
+        max_length=200,
+        null=True,
+        choices=[
+            ("Junior", "Junior"),
+            ("Mid-level", "Mid-level"),
+            ("Lead", "Lead")
+        ],
+        default=None
+    )
+    social_account = models.URLField(max_length=200, null=True)
+    linkedin_account = models.URLField(max_length=200,null=True)
+    private_notes = models.TextField(null=True)
+    
+    def __str__(self):
+        return self.username
+    
 class Skill(models.Model):
     name = models.CharField(max_length=255)
     abbreviation = models.CharField(max_length=255)

--- a/mentorship/users/views.py
+++ b/mentorship/users/views.py
@@ -14,9 +14,24 @@ class UserList(APIView):
     def post(self, request):
         serializer = CustomUserSerializer(data=request.data)
         if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data)
-        return Response(serializer.errors)
+            if request.user.is_staff:
+                serializer.save()
+            else:
+                serializer.save(
+                    is_staff=False,
+                    is_superuser=False,
+                    private_notes=None,
+                    onboarding_status="Applied",
+                    rank="Junior"
+                )
+            return Response(
+                serializer.data,
+                status=status.HTTP_201_CREATED
+            )
+        return Response(
+            serializer.errors,
+            status=status.HTTP_400_BAD_REQUEST
+        )
 
 class UserDetail(APIView):
     def get_object(self, pk):


### PR DESCRIPTION
# Today's pull request is brought to you by security - keep your admin priveleges secure!
- Previously any user could create themselves as a staff or superadmin by setting these fields to 1.
- The POST request has now been modified so that users are restricted in what they can set when creating their user object.
- The below fields are saved as default settings, regardless of what the user enters in the post request:
            - is_staff=False,
            - is_superuser=False,
            - private_notes=None,
            - onboarding_status="Applied",
            - rank="Junior"

## But hold on, what if we want to create another staff or admin user??
Not to worry, friends! The above restrictions are based on conditional logic. If you are an existing staff or admin user, you are able to modify the above fields when creating new users, you just have to be authenticated.

## Other changes include:
- Formatting of ```users/views.py```
- Allowing ```skills``` field in user model to have a null value, as I am currently receiving errors when attempting to create users with skills #shoutouttomyfaveissue issue #7 (apparently I can't have a PR without referencing this issue 😅 ) 
