### PR TITLE
7 multiple skills to user

### DIFF
--- a/mentorship/users/serializers.py
+++ b/mentorship/users/serializers.py
@@ -2,23 +2,52 @@ from rest_framework import serializers
 from .models import CustomUser, Skill
 
 class SkillSerilalizer(serializers.ModelSerializer):
+
     class Meta:
         model = Skill
         fields = ("name",)
 
+class CustomUserSerializerRead(serializers.ModelSerializer):
+    user = serializers.ReadOnlyField(source='user.id')
+    skills = serializers.SerializerMethodField(required=False, read_only=True)
+
+    class Meta:
+        model = CustomUser
+        fields = "__all__"
+        extra_kwargs = {'password': {'write_only': True}, 'email' : {'required': True}}
+
+
+    def get_skills(self, obj):
+        skills = Skill.objects.filter(user_profiles=obj.id)
+        return SkillSerilalizer(skills, many=True).data
+
+
+    def get_restricted_data(self):
+        return {
+            'id': self.id,
+            'username': self.username,
+            'first_name': self.first_name,
+            'last_name': self.last_name,
+            'email': self.email,
+            'mobile': self.mobile,
+            'location': self.location,
+            'cv': self.cv,
+            'skills': self.skills,
+            'social_account': self.social_account,
+            'linkedin_account': self.linkedin_account,
+            'rank': self.rank,
+            'date_joined': self.date_joined
+        }
+
 class CustomUserSerializer(serializers.ModelSerializer):
     user = serializers.ReadOnlyField(source='user.id')
-    skills = serializers.SerializerMethodField()
 
     class Meta:
         model = CustomUser
         fields = ('username', 'first_name', 'last_name','password', 'email',
-                  'mobile', 'location', 'cv', 'skills', 'social_account', 'linkedin_account','user')
+                  'mobile', 'location', 'cv', 'skills', 'social_account', 'linkedin_account','user',)
         extra_kwargs = {'password': {'write_only': True}, 'email' : {'required': True}}
 
-    def get_skills(self, obj):
-        skills = Skill.objects.filter(user_profiles=obj.id)
-        return SkillSerilalizer(skills,many=True).data
 
     def validate_username(self, value):
         if CustomUser.objects.filter(username__iexact=value).exists():
@@ -39,8 +68,11 @@ class CustomUserSerializer(serializers.ModelSerializer):
         for skillset in validated_data.get('skills'):
             user.skills.add(skillset.id)
         return user
-    
+
+
     def update(self,instance,validated_data):
+
+
         instance.username = validated_data.get('username', instance.username)
         instance.first_name = validated_data.get('first_name', instance.first_name)
         instance.last_name = validated_data.get('last_name', instance.last_name)
@@ -48,26 +80,17 @@ class CustomUserSerializer(serializers.ModelSerializer):
         instance.mobile = validated_data.get('mobile',instance.mobile)
         instance.location = validated_data.get('location',instance.location)
         instance.cv = validated_data.get('cv',instance.cv)
-        instance.skills = validated_data.get('skills',instance.skills)
+        #instance.skills = validated_data.get('skills',instance.skills)
         instance.social_account = validated_data.get('social_account',instance.social_account)
         instance.linkedin_account = validated_data.get('linkedin_account',instance.linkedin_account)
+
+        instance.skills.clear()
+
+        for skillset in validated_data.get('skills'):
+            instance.skills.add(skillset.id)
+
         instance.save()
         return instance
     
-    def get_restricted_data(self):
-        return {
-            'id': self.id,
-            'username': self.username,
-            'first_name': self.first_name,
-            'last_name': self.last_name,
-            'email': self.email,
-            'mobile': self.mobile,
-            'location': self.location,
-            'cv': self.cv,
-            'skills': self.skills,
-            'social_account': self.social_account,
-            'linkedin_account': self.linkedin_account,
-            'rank': self.rank,
-            'date_joined': self.date_joined
-        }
+
     

--- a/mentorship/users/serializers.py
+++ b/mentorship/users/serializers.py
@@ -1,14 +1,25 @@
 from rest_framework import serializers
 from .models import CustomUser, Skill
 
+class SkillSerilalizer(serializers.ModelSerializer):
+    class Meta:
+        model = Skill
+        fields = ("name",)
+
 class CustomUserSerializer(serializers.ModelSerializer):
     user = serializers.ReadOnlyField(source='user.id')
+    skills = serializers.SerializerMethodField()
+
     class Meta:
         model = CustomUser
         fields = ('username', 'first_name', 'last_name','password', 'email',
                   'mobile', 'location', 'cv', 'skills', 'social_account', 'linkedin_account','user')
         extra_kwargs = {'password': {'write_only': True}, 'email' : {'required': True}}
-    
+
+    def get_skills(self, obj):
+        skills = Skill.objects.filter(user_profiles=obj.id)
+        return SkillSerilalizer(skills,many=True).data
+
     def validate_username(self, value):
         if CustomUser.objects.filter(username__iexact=value).exists():
             raise serializers.ValidationError("A user with this username already exists.")

--- a/mentorship/users/serializers.py
+++ b/mentorship/users/serializers.py
@@ -5,7 +5,8 @@ class CustomUserSerializer(serializers.ModelSerializer):
     user = serializers.ReadOnlyField(source='user.id')
     class Meta:
         model = CustomUser
-        fields = '__all__'
+        fields = fields = ('username', 'first_name', 'last_name','password', 'email',
+                  'mobile', 'location', 'cv', 'skills', 'social_account', 'linkedin_account','user')
         extra_kwargs = {'password': {'write_only': True}, 'email' : {'required': True}}
     
     def validate_username(self, value):
@@ -14,7 +15,19 @@ class CustomUserSerializer(serializers.ModelSerializer):
         return value
     
     def create(self,validated_data):
-        return CustomUser.objects.create_user(**validated_data)
+        user = CustomUser.objects.create_user(username=validated_data.get('username'),
+                                              first_name=validated_data.get('first_name'),
+                                              last_name=validated_data.get('last_name'),
+                                              email=validated_data.get('email'),
+                                              mobile=validated_data.get('mobile'),
+                                              location=validated_data.get('location'),
+                                              cv=validated_data.get('cv'),
+                                              social_account=validated_data.get('social_account'),
+                                              linkedin_account=validated_data.get('linkedin_account')
+                                              )
+        for skillset in validated_data.get('skills'):
+            user.skills.add(skillset.id)
+        return user
     
     def update(self,instance,validated_data):
         instance.username = validated_data.get('username', instance.username)

--- a/mentorship/users/serializers.py
+++ b/mentorship/users/serializers.py
@@ -44,7 +44,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CustomUser
-        fields = ('username', 'password', 'first_name', 'last_name','password', 'email',
+        fields = ('username', 'password', 'first_name', 'last_name', 'email',
                   'mobile', 'location', 'cv', 'skills', 'social_account', 'linkedin_account','user',)
         extra_kwargs = {'password': {'write_only': True}, 'email' : {'required': True}}
 
@@ -81,7 +81,6 @@ class CustomUserSerializer(serializers.ModelSerializer):
         instance.mobile = validated_data.get('mobile',instance.mobile)
         instance.location = validated_data.get('location',instance.location)
         instance.cv = validated_data.get('cv',instance.cv)
-        #instance.skills = validated_data.get('skills',instance.skills)
         instance.social_account = validated_data.get('social_account',instance.social_account)
         instance.linkedin_account = validated_data.get('linkedin_account',instance.linkedin_account)
 
@@ -92,6 +91,23 @@ class CustomUserSerializer(serializers.ModelSerializer):
 
         instance.save()
         return instance
-    
+
+    def get_restricted_data(self):
+        return {
+            'id': self.id,
+            'username': self.username,
+            'first_name': self.first_name,
+            'last_name': self.last_name,
+            'email': self.email,
+            'mobile': self.mobile,
+            'location': self.location,
+            'cv': self.cv,
+            'skills': self.skills,
+            'social_account': self.social_account,
+            'linkedin_account': self.linkedin_account,
+            'rank': self.rank,
+            'date_joined': self.date_joined
+        }
+
 
     

--- a/mentorship/users/serializers.py
+++ b/mentorship/users/serializers.py
@@ -44,7 +44,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CustomUser
-        fields = ('username', 'first_name', 'last_name','password', 'email',
+        fields = ('username', 'password', 'first_name', 'last_name','password', 'email',
                   'mobile', 'location', 'cv', 'skills', 'social_account', 'linkedin_account','user',)
         extra_kwargs = {'password': {'write_only': True}, 'email' : {'required': True}}
 
@@ -56,6 +56,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
     
     def create(self,validated_data):
         user = CustomUser.objects.create_user(username=validated_data.get('username'),
+                                              password=validated_data.get('password'),
                                               first_name=validated_data.get('first_name'),
                                               last_name=validated_data.get('last_name'),
                                               email=validated_data.get('email'),

--- a/mentorship/users/serializers.py
+++ b/mentorship/users/serializers.py
@@ -1,11 +1,11 @@
 from rest_framework import serializers
-from .models import CustomUser
+from .models import CustomUser, Skill
 
 class CustomUserSerializer(serializers.ModelSerializer):
     user = serializers.ReadOnlyField(source='user.id')
     class Meta:
         model = CustomUser
-        fields = fields = ('username', 'first_name', 'last_name','password', 'email',
+        fields = ('username', 'first_name', 'last_name','password', 'email',
                   'mobile', 'location', 'cv', 'skills', 'social_account', 'linkedin_account','user')
         extra_kwargs = {'password': {'write_only': True}, 'email' : {'required': True}}
     

--- a/mentorship/users/views.py
+++ b/mentorship/users/views.py
@@ -2,16 +2,26 @@ from django.http import Http404
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from .models import CustomUser
+from .models import CustomUser, Skill
 from .serializers import CustomUserSerializer
 
 class UserList(APIView):
+
+    def get_queryset(self):
+        skills = self.request.data['skills']
+        skill_ids = []
+        for skill in skills:
+            skill_ob = Skill.objects.get(name=skill)
+            skill_ids.append((skill_ob.id))
+        return skill_ids
+
     def get(self, request):
         users = CustomUser.objects.all()
         serializer = CustomUserSerializer(users, many=True)
         return Response(serializer.data)
 
     def post(self, request):
+        request.data['skills'] = self.get_queryset()
         serializer = CustomUserSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()

--- a/mentorship/users/views.py
+++ b/mentorship/users/views.py
@@ -22,7 +22,6 @@ class UserList(APIView):
 
     def post(self, request):
         request.data['skills'] = self.get_queryset()
-        print(request.data)
         serializer = CustomUserSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
# All the Skills 💃

Changes to the user app view.py and serializer.py were made to accommodate a M:M relationship between the Skills model and the CustomUser model.

Not sure if this the best approach/solution but it seems to work 🤷‍♀️ 

Addresses issue #7 

 ***

## POST workflow
For user creation workflow, the view.py views do a queryset override to map string representations of skill names to their respective ids in the Skills table, and returns/replaces the request.data['skills'] with the ids to pass into the serializer.

The serializer was then altered to:

- create the user object first, then,
- create the M:M relation to skills, based on supplied ids.

 ***

## GET workflow
To deserialize/fetch the skills, two separate serializers was created - because for the life of me I could not figure out how to do it in the one serializer.

The 'read' serializer outputs all fields, and inserts the Skills through the relationship to user through a SerializerMethodField.
The GET requests of the UserDetail and UserList  in the views.py were then updated to call this serializer instead.

 ***

Happy comparing :dancers: 
