### PR TITLE
Adding check for event publish status on POST

### DIFF
--- a/mentorship/events/views.py
+++ b/mentorship/events/views.py
@@ -77,10 +77,6 @@ class EventMentorList(APIView):
     def post(self, request):
         serializer = EventMentorsSerializer(data=request.data)
 
-        # I think we may need to break out the assignment of mentor_id below, so that
-        # an is_staff usertype can assign mentors to an event as well as mentors self-assigning
-        # - eg Lachlan also has the option to manually assign mentors a, b, c to event x.
-
         if Event.objects.get(id=request.data['event_id']).is_published:
             if serializer.is_valid():
                 serializer.save(
@@ -90,7 +86,9 @@ class EventMentorList(APIView):
                 )
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-        return Response("Event must be published before a mentor can be assigned", status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+                {"detail": "Event must be published before a mentor can be assigned."},
+                status=status.HTTP_400_BAD_REQUEST)
 
 class EventMentorDetail(APIView):
     permission_classes = [CustomIsAdmin]


### PR DESCRIPTION
## Check if an Event has status of Published before POST

Add some logic to the EventMentorList view to:

check if the specified event_id (in request.data) has boolean true for is_published 
 - if so, proceed to serializer,
 - if not, return a message/400.

Happy to change the message/http status code to something else more creative/useful if needed?

Addresses issue #5 
