### PR TITLE
Adding created_by as a read only field in Event Serializer to align with how created by is set in POST request

### DIFF
--- a/mentorship/events/serializers.py
+++ b/mentorship/events/serializers.py
@@ -3,6 +3,7 @@ from django.apps import apps
 
 class EventSerializer(serializers.ModelSerializer):
   modified_by = serializers.ReadOnlyField(source='modified_by.id')
+  created_by = serializers.ReadOnlyField(source='created_by.id')
   class Meta:
     model = apps.get_model('events.Event')
     fields = '__all__'


### PR DESCRIPTION
Nothing too exciting this time!
I noticed when reviewing PR 17 that the event POST request threw an error unless you specified created_by in the JSON body. This is completely redundant as the POST request has been designed to grab the request.user for the created_by field anyway.
To correct this, I've added created_by as a read only field to the EventList Serializer.