### PR TITLE
2 limit fields non staffadmin users can see for user profiles

### DIFF
--- a/mentorship/users/models.py
+++ b/mentorship/users/models.py
@@ -7,6 +7,7 @@ class CustomUser(AbstractUser):
   skills = models.ManyToManyField(
         to='users.Skill',  # use a string in the format `app_name.model_name` to reference models to avoid issues using the model before it was defined
         related_name='user_profiles',  # the name for that relation from the point of view of a skill
+        null=True
     )
   onboarding_status = models.CharField(
       max_length=200,

--- a/mentorship/users/serializers.py
+++ b/mentorship/users/serializers.py
@@ -39,7 +39,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
             'mobile': self.mobile,
             'location': self.location,
             'cv': self.cv,
-            'skills': self.skills,
+            'skills': self.skills.all(),
             'social_account': self.social_account,
             'linkedin_account': self.linkedin_account,
             'rank': self.rank,

--- a/mentorship/users/serializers.py
+++ b/mentorship/users/serializers.py
@@ -83,7 +83,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
             'mobile': self.mobile,
             'location': self.location,
             'cv': self.cv,
-            'skills': self.skills.all(),
+            'skills': SkillSerilalizer(Skill.objects.filter(user_profiles=self.id), many=True).data,
             'social_account': self.social_account,
             'linkedin_account': self.linkedin_account,
             'rank': self.rank,

--- a/mentorship/users/views.py
+++ b/mentorship/users/views.py
@@ -13,9 +13,10 @@ class UserList(APIView):
             serializer = CustomUserSerializer(users, many=True)
             return Response(serializer.data)
         elif request.user.is_authenticated:
-            users = CustomUser.objects.all().filter(pk=self.request.user.id)
-            serializer = CustomUserSerializer(users, many=True)
-            return Response(serializer.data)
+            users = CustomUser.objects.all().get(pk=self.request.user.id)
+            data = CustomUserSerializer.get_restricted_data(users)
+            serializer = CustomUserSerializer(users, data=data,many=True)
+            return Response(serializer.initial_data)
         else:
             return Response(
                 { "detail": "You do not have permission to perform this action." }, 

--- a/mentorship/users/views.py
+++ b/mentorship/users/views.py
@@ -41,10 +41,16 @@ class UserDetail(APIView):
         except CustomUser.DoesNotExist:
             raise Http404
         
-    def get(self, request, pk):
+    def get(self,request,pk):
         user = self.get_object(pk)
-        serializer = CustomUserSerializer(user)
-        return Response(serializer.data)
+        self.check_object_permissions(self.request,user)
+        if request.user.is_staff:
+            serializer = CustomUserSerializer(user)
+            return Response(serializer.data)
+        else:
+            data = CustomUserSerializer.get_restricted_data(user)
+            serializer = CustomUserSerializer(user,data=data)
+            return Response(serializer.initial_data)
     
     def put(self,request,pk):
         user = self.get_object(pk)      

--- a/mentorship/users/views.py
+++ b/mentorship/users/views.py
@@ -19,12 +19,12 @@ class UserList(APIView):
     def get(self,request):
         if request.user.is_staff:
             users = CustomUser.objects.all()
-            serializer = CustomUserSerializer(users, many=True)
+            serializer = CustomUserSerializerRead(users, many=True)
             return Response(serializer.data)
         elif request.user.is_authenticated:
-            users = CustomUser.objects.all().get(pk=self.request.user.id)
+            users = CustomUser.objects.get(pk=self.request.user.id)
             data = CustomUserSerializer.get_restricted_data(users)
-            serializer = CustomUserSerializer(users, data=data,many=True)
+            serializer = CustomUserSerializerRead(users, data=data)
             return Response(serializer.initial_data)
         else:
             return Response(
@@ -63,7 +63,7 @@ class UserDetail(APIView):
         user = self.get_object(pk)
         self.check_object_permissions(self.request,user)
         if request.user.is_staff:
-            serializer = CustomUserSerializer(user)
+            serializer = CustomUserSerializerRead(user)
             return Response(serializer.data)
         else:
             data = CustomUserSerializer.get_restricted_data(user)


### PR DESCRIPTION
# This is the last major user issue before we deploy
This change limits non staff users view of their own user objects. If a user is not staff, they can now only view the following fields:
- id
- username
- first_name
- last_name
- email
- mobile
- location
- cv
- skills
- social_account
- linkedin_account
- rank
- date_joined
