### PR TITLE
Adding current user view

### DIFF
--- a/mentorship/users/urls.py
+++ b/mentorship/users/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [  
     path('users/', views.UserList.as_view()), 
     path('users/<int:pk>/', views.UserDetail.as_view()),
+    path('users/self/', views.CurrentUserView.as_view()),
 ]

--- a/mentorship/users/views.py
+++ b/mentorship/users/views.py
@@ -113,3 +113,18 @@ class UserDetail(APIView):
             serializer.errors,
             status=status.HTTP_400_BAD_REQUEST
         )
+
+class CurrentUserView(APIView):
+    def get(self, request):
+        if request.user.is_staff:
+            serializer = CustomUserSerializerRead(request.user)
+            return Response(serializer.data)
+        elif request.user.is_authenticated:
+            data = CustomUserSerializer.get_restricted_data(request.user)
+            serializer = CustomUserSerializer(request.user,data=data)
+            return Response(serializer.initial_data)
+        else:
+            return Response(
+                { "detail": "You are not currently logged in." }, 
+                status=status.HTTP_404_NOT_FOUND
+            )


### PR DESCRIPTION
# New endpoint!
- This is to help us get our current user information, as we've tightened up our security around getting user information.
- The new endpoint is `users/self/`

# How to test
- Pull down a local copy of this branch, get a user token (try both for staff and non staff users 😉 )
- Make a GET request to http://127.0.0.1:8000/users/self/ using different user tokens
- Test out what happens when you don't provide a user token!

# Front end implementation
- This endpoint will help to load profile information along with check if current users are staff (e.g. what elements of the navbar to display etc)

Let me know what you think!